### PR TITLE
style: Update inquiry forms

### DIFF
--- a/frontend/views/destination/activities.php
+++ b/frontend/views/destination/activities.php
@@ -58,10 +58,13 @@ $this->params['breadcrumbs'][] = Yii::t('app','Activities');
 </div>
 
 <div class="form-info container">
-  <h2><?=Yii::t('app',"Customize a tour that includes a visit to this destination.")?></h2>
+  <div class="text-before-iquiry-form col-lg-8 col-md-8 col-xs-12">
+  	<h2><?=Yii::t('app',"Customize a tour that includes a visit to this destination")?></h2>
+  </div>
   <div class="form-info-create col-lg-8 col-md-8 col-xs-12">
     <span class="placeholder" id="inquiry-form"></span>
-    <div class="form-title"><?=Yii::t('app','Customization Form')?></div>
+	<h2><?=Yii::t('app',"Inquiry Form")?></h2>
+	<div class="tips">Let's get started! Fill out this form so we can start helping you plan your adventure in China.</div>
 
     <?= $this->render('/form-info/_form', [
         'model' => new common\models\FormInfo(FORM_TYPE_CUSTOM),

--- a/frontend/views/destination/experiences.php
+++ b/frontend/views/destination/experiences.php
@@ -70,10 +70,13 @@ $this->params['breadcrumbs'][] = Yii::t('app','Experiences');
 </div>
 
 <div class="form-info container">
-  <h2><?=Yii::t('app',"Customize a tour that includes a visit to this destination.")?></h2>
+  <div class="text-before-iquiry-form col-lg-8 col-md-8 col-xs-12">
+  	<h2><?=Yii::t('app',"Customize a tour that includes a visit to this destination")?></h2>
+  </div>
   <div class="form-info-create col-lg-8 col-md-8 col-xs-12">
     <span class="placeholder" id="inquiry-form"></span>
-    <div class="form-title"><?=Yii::t('app','Customization Form')?></div>
+	<h2><?=Yii::t('app',"Inquiry Form")?></h2>
+	<div class="tips">Let's get started! Fill out this form so we can start helping you plan your adventure in China.</div>
 
     <?= $this->render('/form-info/_form', [
         'model' => new common\models\FormInfo(FORM_TYPE_CUSTOM),

--- a/frontend/views/destination/food.php
+++ b/frontend/views/destination/food.php
@@ -33,10 +33,13 @@ $this->params['breadcrumbs'][] = Yii::t('app','Food');
 </div>
 
 <div class="form-info container">
-  <h2><?=Yii::t('app',"Customize a tour that includes a visit to this destination.")?></h2>
+  <div class="text-before-iquiry-form col-lg-8 col-md-8 col-xs-12">
+  	<h2><?=Yii::t('app',"Customize a tour that includes a visit to this destination")?></h2>
+  </div>
   <div class="form-info-create col-lg-8 col-md-8 col-xs-12">
     <span class="placeholder" id="inquiry-form"></span>
-    <div class="form-title"><?=Yii::t('app','Customization Form')?></div>
+	<h2><?=Yii::t('app',"Inquiry Form")?></h2>
+	<div class="tips">Let's get started! Fill out this form so we can start helping you plan your adventure in China.</div>
 
     <?= $this->render('/form-info/_form', [
         'model' => new common\models\FormInfo(FORM_TYPE_CUSTOM),

--- a/frontend/views/destination/sights.php
+++ b/frontend/views/destination/sights.php
@@ -59,10 +59,13 @@ $this->params['breadcrumbs'][] = Yii::t('app','Sights');
 </div>
 
 <div class="form-info container">
-  <h2><?=Yii::t('app',"Customize a tour that includes a visit to this destination.")?></h2>
+  <div class="text-before-iquiry-form col-lg-8 col-md-8 col-xs-12">
+  	<h2><?=Yii::t('app',"Customize a tour that includes a visit to this destination")?></h2>
+  </div>
   <div class="form-info-create col-lg-8 col-md-8 col-xs-12">
     <span class="placeholder" id="inquiry-form"></span>
-    <div class="form-title"><?=Yii::t('app','Customization Form')?></div>
+	<h2><?=Yii::t('app',"Inquiry Form")?></h2>
+	<div class="tips">Let's get started! Fill out this form so we can start helping you plan your adventure in China.</div>
 
     <?= $this->render('/form-info/_form', [
         'model' => new common\models\FormInfo(FORM_TYPE_CUSTOM),

--- a/frontend/views/destination/view.php
+++ b/frontend/views/destination/view.php
@@ -32,11 +32,13 @@ $this->params['breadcrumbs'][] = $city_info['name'];
 </div>
 
 <div class="form-info container">
-  <h2><?=Yii::t('app',"Customize a tour that includes a visit to this destination.")?></h2>
+  <div class="text-before-iquiry-form col-lg-8 col-md-8 col-xs-12">
+  	<h2><?=Yii::t('app',"Customize a tour that includes a visit to this destination")?></h2>
+  </div>
   <div class="form-info-create col-lg-8 col-md-8 col-xs-12">
     <span class="placeholder" id="inquiry-form"></span>
-    <div class="form-title"><?=Yii::t('app','Customization Form')?></div>
-
+    <h2><?=Yii::t('app',"Inquiry Form")?></h2>
+	<div class="tips">Let's get started! Fill out this form so we can start helping you plan your adventure in China.</div>
     <?= $this->render('/form-info/_form', [
         'model' => new common\models\FormInfo(FORM_TYPE_CUSTOM),
         'form_type' => FORM_TYPE_CUSTOM,

--- a/frontend/views/destination/virtualtours.php
+++ b/frontend/views/destination/virtualtours.php
@@ -29,10 +29,13 @@ $this->params['breadcrumbs'][] = Yii::t('app','Virtual Tours');
 </div>
 
 <div class="form-info container">
-  <h2><?=Yii::t('app',"Customize a tour that includes a visit to this destination.")?></h2>
+  <div class="text-before-iquiry-form col-lg-8 col-md-8 col-xs-12">
+  	<h2><?=Yii::t('app',"Customize a tour that includes a visit to this destination")?></h2>
+  </div>
   <div class="form-info-create col-lg-8 col-md-8 col-xs-12">
     <span class="placeholder" id="inquiry-form"></span>
-    <div class="form-title"><?=Yii::t('app','Customization Form')?></div>
+    <h2><?=Yii::t('app',"Inquiry Form")?></h2>
+	<div class="tips">Let's get started! Fill out this form so we can start helping you plan your adventure in China.</div>
 
     <?= $this->render('/form-info/_form', [
         'model' => new common\models\FormInfo(FORM_TYPE_CUSTOM),

--- a/frontend/views/educational-programs/index.php
+++ b/frontend/views/educational-programs/index.php
@@ -45,8 +45,8 @@ $this->params['breadcrumbs'][] = $this->title;
 <div class="form-info container">
   <div class="form-info-create col-lg-8 col-md-8 col-xs-12">
     <span class="placeholder" id="inquiry-form"></span>
-    <div class="form-title"><?=Yii::t('app','Information Form')?></div>
-
+    <!-- <div class="form-title"><?=Yii::t('app','Information Form')?></div> -->
+    <h2><?=Yii::t('app',"Inquiry Form")?></h2>
     <?= $this->render('/form-info/_form', [
         'model' => new common\models\FormInfo(FORM_TYPE_EDU),
         'form_type' => FORM_TYPE_EDU,

--- a/frontend/views/experience/index.php
+++ b/frontend/views/experience/index.php
@@ -99,11 +99,13 @@ $this->params['breadcrumbs'][] = $this->title;
 </div>
 
 <div class="form-info container">
-  <h2><?=Yii::t('app',"Can't find what you're looking for? Contact us today to customize your tour.")?></h2>
+  <div class="text-before-iquiry-form col-lg-8 col-md-8 col-xs-12">
+  	<h2><?=Yii::t('app',"Can't find what you're looking for? Contact us today to customize your tour")?></h2>
+  </div>
   <div class="form-info-create col-lg-8 col-md-8 col-xs-12">
     <span class="placeholder" id="inquiry-form"></span>
-    <div class="form-title"><?=Yii::t('app','Customization Form')?></div>
-
+	<h2><?=Yii::t('app',"Inquiry Form")?></h2>
+	<div class="tips">Let's get started! Fill out this form so we can start helping you plan your adventure in China.</div>
     <?= $this->render('/form-info/_form', [
         'model' => new common\models\FormInfo(FORM_TYPE_CUSTOM),
         'form_type' => FORM_TYPE_CUSTOM,

--- a/frontend/views/experience/search.php
+++ b/frontend/views/experience/search.php
@@ -167,11 +167,13 @@ $this->params['breadcrumbs'][] = $this->title;
 </div>
 
 <div class="form-info container">
-  <h2><?=Yii::t('app',"Can't find what you're looking for? Contact us today to customize your tour.")?></h2>
+  <div class="text-before-iquiry-form col-lg-8 col-md-8 col-xs-12">
+  	<h2><?=Yii::t('app',"Can't find what you're looking for? Contact us today to customize your tour")?></h2>
+  </div>
   <div class="form-info-create col-lg-8 col-md-8 col-xs-12">
     <span class="placeholder" id="inquiry-form"></span>
-    <div class="form-title"><?=Yii::t('app','Customization Form')?></div>
-
+    <h2><?=Yii::t('app',"Inquiry form")?></h2>
+	<div class="tips">Let's get started! Fill out this form so we can start helping you plan your adventure in China.</div>
     <?= $this->render('/form-info/_form', [
         'model' => new common\models\FormInfo(FORM_TYPE_CUSTOM),
         'form_type' => FORM_TYPE_CUSTOM,

--- a/frontend/views/experience/view.php
+++ b/frontend/views/experience/view.php
@@ -260,12 +260,11 @@ $this->params['breadcrumbs'][] = $tour_info['name'];
       <div class="form-info-create">
         <span class="placeholder" id="inquiry-form"></span>
         <!-- <div class="form-title"><?=Yii::t('app','Quotation Form')?></div> -->
-        <h2 style="margin-top: 0;text-align: center;"><?= $tour_info['name'] ?></h2>
+        <h2><?=Yii::t('app',"Inquiry Form")?></h2>
         <!-- <div class="tips"><?= ($tour_info['tour_length']==intval($tour_info['tour_length']))?intval($tour_info['tour_length']):$tour_info['tour_length'] ?>
               <?=($tour_info['tour_length']>1)?Yii::t('app','Days'):Yii::t('app','Day')?> | <?= $tour_info['display_cities'] ?> <?=Yii::t('app','Private Tour')?></div>
         <div class="tips"><?=Yii::t('app','Tour Code:')?> <?= $tour_info['code'] ?></div> -->
-        <div class="tips">Let's get started! Fill out this form so we can start helping you plan your adventure in China.</div>
-        <hr />
+        <div class="tips"><?= $tour_info['name'] ?> - <?= $tour_info['code'] ?></div>
         <?= $this->render('/form-info/_form', [
             'model' => new common\models\FormInfo(FORM_TYPE_QUOTATION),
             'form_type' => FORM_TYPE_QUOTATION,

--- a/frontend/views/form-card/_form.php
+++ b/frontend/views/form-card/_form.php
@@ -10,7 +10,7 @@ use yii\helpers\Url;
 ?>
 
 <div class="form-card-form">
-
+	<hr />
     <?php $form = ActiveForm::begin(['id'=>'form-card-form']) ?>
 
     <div class="required">

--- a/frontend/views/form-card/create.php
+++ b/frontend/views/form-card/create.php
@@ -12,10 +12,12 @@ $this->params['breadcrumbs'][] = $this->title;
 ?>
 
 <div class="form-info container">
-  <h2><?=Yii::t('app',"Please inform your bank or credit card issuer that you will be receiving a charge from China. ")?></h2>
+  <!-- <h2><?=Yii::t('app',"Please inform your bank or credit card issuer that you will be receiving a charge from China.")?></h2> -->
   <div class="form-info-create col-lg-8 col-md-8 col-xs-12">
   	<span class="placeholder" id="inquiry-form"></span>
-    <div class="form-title"><?=Yii::t('app','Secure Credit Card Form')?></div>
+    <!-- <div class="form-title"><?=Yii::t('app','Secure Credit Card Form')?></div> -->
+    <h2><?=Yii::t('app',"Secure Credit Card Form")?></h2>
+	<div class="tips">Please inform your bank or credit card issuer that you will be receiving a charge from China.</div>
 
     <?= $this->render('/form-card/_form', [
         'model' => new common\models\FormCard(),

--- a/frontend/views/form-info/_form.php
+++ b/frontend/views/form-info/_form.php
@@ -10,7 +10,7 @@ use yii\helpers\Url;
 ?>
 
 <div class="form-info-form">
-
+    <hr />
     <?php $form = ActiveForm::begin(['action' => Url::toRoute(['form-info/create', 'form_type' => $form_type]), 'id'=>'form-info-form']);
         $form_fields = Yii::$app->params['form_fields'][$form_type]; 
         if (!isset($tour_id)) {

--- a/frontend/views/mice/index.php
+++ b/frontend/views/mice/index.php
@@ -45,8 +45,8 @@ $this->params['breadcrumbs'][] = $this->title;
 <div class="form-info container">
   <div class="form-info-create col-lg-8 col-md-8 col-xs-12">
     <span class="placeholder" id="inquiry-form"></span>
-    <div class="form-title"><?=Yii::t('app','Information Form')?></div>
-
+    <!-- <div class="form-title"><?=Yii::t('app','Information Form')?></div> -->
+    <h2><?=Yii::t('app',"Inquiry Form")?></h2>
     <?= $this->render('/form-info/_form', [
         'model' => new common\models\FormInfo(FORM_TYPE_MICE),
         'form_type' => FORM_TYPE_MICE,

--- a/frontend/web/statics/css/site.css
+++ b/frontend/web/statics/css/site.css
@@ -799,7 +799,7 @@ div#social-media-icons-container a {
 }
 
 .form-info h2 {
-    color: #c78d00;
+    color: #4D423C;
     font-size: 30px;
     text-align: center;
     font-family: "Times New Roman";
@@ -811,6 +811,16 @@ div#social-media-icons-container a {
     text-align: center;
     font-family: "Times New Roman";
     margin-top: 3px;
+}
+
+.text-before-iquiry-form {
+    clear: both;
+    float: none;
+    margin: 0 auto;
+}
+
+.text-before-iquiry-form h2 {
+	color: #E9C46C;
 }
 
 .form-info-create
@@ -826,6 +836,15 @@ div#social-media-icons-container a {
 .form-info-create .has-success .control-label, .form-info-create .has-error .control-label{
   color: #524632;
 }
+
+.form-info-create h2 {
+	margin-top: 0px;
+}
+
+.form-info-create hr {
+	margin: 20px 0;
+}
+
 .subscribe-mail-form{
   padding: 20px;
   text-align: left;


### PR DESCRIPTION

This update:

- moves the titles of the inquiry forms to inside the boxes and, in some cases, adds a small explanation sentence after the title (e.g. credit card form);

- adds a thin ruler separating the forms' title from the content;

- changes the color and width of the sentences before the inquiry forms.