### PR TITLE
Various changes to OA Book Cost and OA Payment

### DIFF
--- a/backend/views/oa-book-cost/_form.php
+++ b/backend/views/oa-book-cost/_form.php
@@ -59,13 +59,15 @@ use yii\helpers\ArrayHelper;
     
     <?= $form->field($model, 'pay_status')->dropdownList(common\models\Tools::getEnvironmentVariable('oa_pay_status'), ['disabled' => !$permission['canAdd']]) ?>
 
+    <?= $form->field($model, 'confirmed_amount')->textInput(['maxlength' => true, 'disabled' => !$permission['canAdd']]) ?>
+
+    <?= $form->field($model, 'pay_amount')->textInput(['maxlength' => true, 'disabled' => !$permission['canAdd']]) ?>
+
 	<?php if($permission['canAdd']): $template = '{label} &nbsp;&nbsp;&nbsp;(<a class="bt_clear_item" href="javascript:void(0);">Clear</a>) {input}{error}{hint}'; else: $template = '{label} {input}{error}{hint}'; endif;?>
 
     <?= $form->field($model, 'pay_date', [
         'template' => $template
 		])->textInput(['maxlength' => true, 'disabled' => !$permission['canAdd']]) ?>
-
-    <?= $form->field($model, 'pay_amount')->textInput(['maxlength' => true, 'disabled' => !$permission['canAdd']]) ?>
 
     <?= $form->field($model, 'pay_method')->dropdownList(common\models\Tools::getEnvironmentVariable('oa_pay_method'), ['prompt' => '--Select--', 'disabled' => !$permission['canAdd']]) ?>
 

--- a/backend/views/oa-book-cost/index.php
+++ b/backend/views/oa-book-cost/index.php
@@ -106,11 +106,19 @@ $this->params['breadcrumbs'][] = $this->title;
                     return $data['pay_status'] == 0 ? 'Not Paid' : 'Paid';
                 }
             ],
-            'pay_date',
+            [
+                'attribute'=>'confirmed_amount',
+                'label' => 'Confirmed Amount',
+				'footer' => \common\models\Tools::getTotal($dataProvider->models, 'confirmed_amount'),
+            ],
             [
                 'attribute'=>'pay_amount',
-                'label' => 'Pay Amount',
+                'label' => 'Accounting Amount',
 				'footer' => \common\models\Tools::getTotal($dataProvider->models, 'pay_amount'),
+            ],
+            [
+                'attribute'=>'pay_date',
+                'label' => 'Accounting Date',
             ],
             [
                 'attribute' => 'pay_method',

--- a/backend/views/oa-book-cost/view.php
+++ b/backend/views/oa-book-cost/view.php
@@ -58,11 +58,15 @@ $this->params['breadcrumbs'][] = $this->title;
             ],
             'due_date_for_pay',
             'pay_status',
-            'pay_date',
+            [
+	            'attribute' => 'confirmed_amount',
+	            'label' => 'Confirmed Amount'
+            ],
             [
 	            'attribute' => 'pay_amount',
-	            'label' => 'Pay Amount'
+	            'label' => 'Accounting Amount'
             ],
+            'pay_date',
             'pay_method',
             'transaction_fee',
             'transaction_note:ntext',

--- a/backend/views/oa-inquiry/view.php
+++ b/backend/views/oa-inquiry/view.php
@@ -157,6 +157,7 @@ $inquiryAssignedToTour =  \common\models\Tools::inquiryAssignedToTour($model->id
     <div id="itinerary_list">
         <?= GridView::widget([
                 'dataProvider' => $dataProvider,
+				'showFooter' => true,
                 'columns' => [
 			        [
 			            'label' => 'ID',
@@ -165,6 +166,7 @@ $inquiryAssignedToTour =  \common\models\Tools::inquiryAssignedToTour($model->id
 			            'value' => function ($data) {
 			                return Html::a('P'. $data['id'], ['oa-payment/view', 'id' => $data['id']], ['data-pjax' => 0, 'target' => "_blank"]);
 			            },
+						'footer' => 'Total'
 			        ],
                     [
 	                    'attribute' => 'payer_type',
@@ -183,7 +185,10 @@ $inquiryAssignedToTour =  \common\models\Tools::inquiryAssignedToTour($model->id
 	                    'label' => 'Guest Name',
                     ],
                     'type',
-                    'cny_amount',
+                    [
+	                    'attribute' => 'cny_amount',
+	                    'label' => 'Amount',
+                    ],
                     'due_date',
                     [
 	                    'attribute' => 'pay_method',
@@ -203,10 +208,19 @@ $inquiryAssignedToTour =  \common\models\Tools::inquiryAssignedToTour($model->id
 	                    }
                     ],
                     [
-                    	'attribute' => 'receit_cny_amount',
-                    	'label' => 'Receipt Amount'
+                    	'attribute' => 'confirmed_amount',
+                    	'label' => 'Confirmed Amount',
+						'footer' => \common\models\Tools::getTotal($dataProvider->models, 'confirmed_amount'),
                     ],
-                    'receit_date',
+                    [
+                    	'attribute' => 'receit_cny_amount',
+                    	'label' => 'Accounting Amount',
+						'footer' => \common\models\Tools::getTotal($dataProvider->models, 'receit_cny_amount'),
+                    ],
+                    [
+	                    'attribute' => 'receit_date',
+	                    'label' => 'Accounting Date',
+                    ],
                 ],
             ]); ?>
     </div>

--- a/backend/views/oa-payment/_form.php
+++ b/backend/views/oa-payment/_form.php
@@ -30,15 +30,25 @@ use yii\widgets\ActiveForm;
 
     <?= $form->field($model, 'status')->dropdownList(common\models\Tools::getEnvironmentVariable('oa_pay_status'), ['disabled' => !$permission['canAdd']]) ?>
 
+    <?= $form->field($model, 'confirmed_amount')->textInput(['maxlength' => true, 'disabled' => !$permission['canAdd']]) ?>
+
     <?php /*$form->field($model, 'receit_account')->dropdownList(common\models\Tools::getEnvironmentVariable('oa_receit_account'), ['disabled' => !$permission['canAdd']])*/ ?>
 
     <?= $form->field($model, 'receit_cny_amount')->textInput(['maxlength' => true, 'disabled' => !$permission['canAdd']]) ?>
 
     <?= $form->field($model, 'transaction_fee')->textInput(['maxlength' => true, 'disabled' => !$permission['canAdd']]) ?>
 
-    <?= $form->field($model, 'receit_date')->textInput(['maxlength' => true, 'disabled' => !$permission['canAdd']]) ?>
+	<?php if($permission['canAdd']): $template = '{label} &nbsp;&nbsp;&nbsp;(<a class="bt_clear_item" href="javascript:void(0);">Clear</a>) {input}{error}{hint}'; else: $template = '{label} {input}{error}{hint}'; endif;?>
+
+    <?= $form->field($model, 'receit_date', [
+        'template' => $template
+		])->textInput(['maxlength' => true, 'disabled' => !$permission['canAdd']]) ?>
+		
+		
 
     <?= $form->field($model, 'cc_note_signing')->dropdownList(['To be Signed'=>'To be Signed','Signed'=>'Signed','No Sign'=>'No Sign'], ['prompt' => '--Select--', 'disabled' => !$permission['canAdd']]) ?>
+
+    <?= $form->field($model, 'transaction_note')->textarea(['rows' => 6, 'disabled' => !$permission['canAdd']]) ?>
 
     <?= $form->field($model, 'note')->textarea(['rows' => 6]) ?>
 
@@ -55,7 +65,11 @@ $this->registerCssFile('@web/statics/css/bootstrap-datepicker3.min.css',['depend
 $this->registerJsFile('@web/statics/js/bootstrap-datepicker.min.js',['depends'=>['backend\assets\AppAsset']]);
 $js = <<<JS
     $(function(){
-        $("#oapayment-due_date, #oapayment-receit_date").attr("readonly","readonly").datepicker({ format: 'yyyy-mm-dd' });
+        $("#oapayment-due_date, #oapayment-receit_date").attr("readonly","readonly").datepicker({ format: 'yyyy-mm-dd' }); 
+        
+        $(".bt_clear_item").click(function(){
+            $(this).next().val("");
+        });
     });
 JS;
 $this->registerJs($js);

--- a/backend/views/oa-payment/index.php
+++ b/backend/views/oa-payment/index.php
@@ -85,20 +85,38 @@ HTML;
                 'value' => function ($data) {
 	                $notPaid = 'Not Paid';
 	                $paid = 'Paid';
+	                $note = '';
+	                $transactionNote = '';
+                	
+                	if(!empty(htmlspecialchars($data["transaction_note"]))):
+						$transactionNote = 'Transaction Note: '.htmlspecialchars($data["transaction_note"]).'<br><br>';
+                	endif;
 	                
-	                if(!empty($data['note'])):
-	                	return $data['status'] == 0 ? '<a tabindex="0" data-html="true" data-placement="left" data-toggle="popover" data-trigger="focus" title="Note" data-content="'.htmlspecialchars($data["note"]).'" style="text-decoration: underline; cursor:pointer;">'.$notPaid.'</a>' : '<a tabindex="0" data-html="true" data-placement="left" data-toggle="popover" data-trigger="focus" title="Note" data-content="'.htmlspecialchars($data["note"]).'" style="text-decoration: underline; cursor:pointer;">'.$paid.'</a>';
+                	if(!empty(htmlspecialchars($data["note"]))):
+                		$note = 'Note: '.htmlspecialchars($data["note"]);
+                	endif;
+	                	
+	                if(!empty($note) || !empty($transationNote)):
+	                	return $data['status'] == 0 ? '<a tabindex="0" data-html="true" data-placement="left" data-toggle="popover" data-trigger="focus" title="Notes" data-content="'.$transactionNote.$note.'" style="text-decoration: underline; cursor:pointer;">'.$notPaid.'</a>' : '<a tabindex="0" data-html="true" data-placement="left" data-toggle="popover" data-trigger="focus" title="Notes" data-content="'.$transactionNote.$note.'" style="text-decoration: underline; cursor:pointer;">'.$paid.'</a>';
 	  	            endif;
 	  	            
                     return $data['status'] == 0 ? $notPaid : $paid;
                 }
             ],
             [
-				'label'=>'Receipt Amount',
+				'label'=>'Confirmed Amount',
+				'attribute'=>'confirmed_amount',
+				'footer' => \common\models\Tools::getTotal($dataProvider->models, 'receit_cny_amount'),
+            ],
+            [
+				'label'=>'Accounting Amount',
 				'attribute'=>'receit_cny_amount',
 				'footer' => \common\models\Tools::getTotal($dataProvider->models, 'receit_cny_amount'),
             ],
-            'receit_date',
+            [
+				'label'=>'Accounting Date',
+				'attribute'=>'receit_date',
+            ],
             [
                 'attribute' => 'pay_method',
                 'label'=>'Method',

--- a/backend/views/oa-payment/view.php
+++ b/backend/views/oa-payment/view.php
@@ -73,17 +73,24 @@ $this->params['breadcrumbs'][] = $this->title;
                 'attribute'=>'status',
                 'value' => $model->status == 0 ? 'Not Paid' : 'Paid',
             ],
-            // 'receit_account',
+            [
+			    'attribute' => 'confirmed_amount',
+	            'label' => 'Confirmed Amount'
+			],
             [
 			    'attribute' => 'receit_cny_amount',
-	            'label' => 'Receipt Amount'
+	            'label' => 'Accounting Amount'
 			],
             [
 			    'attribute' => 'transaction_fee',
 	            'label' => 'Transaction Fee'
 			],
-            'receit_date',
+            [
+			    'attribute' => 'receit_date',
+	            'label' => 'Accounting Date'
+			],
             'cc_note_signing',
+            'transaction_note:ntext',
             'note:ntext',
         ],
     ]) ?>

--- a/common/models/OaBookCost.php
+++ b/common/models/OaBookCost.php
@@ -21,6 +21,7 @@ use Yii;
  * @property string $cny_amount
  * @property string $due_date_for_pay
  * @property integer $pay_status
+ * @property string $confirmed_amount
  * @property string $pay_date
  * @property string $pay_amount
  * @property integer $pay_method
@@ -51,7 +52,7 @@ class OaBookCost extends \yii\db\ActiveRecord
             ['transaction_fee', 'number'],
             [['create_time', 'updat_time'], 'safe'],
             [['cl_info', 'transaction_note', 'note'], 'string'],
-            [['cny_amount', 'pay_amount'], 'number'],
+            [['cny_amount', 'pay_amount', 'confirmed_amount'], 'number'],
             [['book_date'], 'string', 'max' => 10],
             [['start_date', 'end_date', 'due_date_for_pay', 'pay_date', 'book_status'], 'string', 'max' => 255],
         ];
@@ -77,8 +78,9 @@ class OaBookCost extends \yii\db\ActiveRecord
             'cny_amount' => Yii::t('app', 'Estimated Amount (CNY)'),
             'due_date_for_pay' => Yii::t('app', 'Due Date'),
             'pay_status' => Yii::t('app', 'Pay Status'),
-            'pay_date' => Yii::t('app', 'Pay Date'),
-            'pay_amount' => Yii::t('app', 'Pay Amount (CNY)'),
+            'confirmed_amount' => Yii::t('app', 'Confirmed Amount (CNY)'),
+            'pay_date' => Yii::t('app', 'Accounting Date'),
+            'pay_amount' => Yii::t('app', 'Accounting Amount (CNY)'),
             'pay_method' => Yii::t('app', 'Pay Method'),
             'transaction_fee' => Yii::t('app', 'Transaction Fee'),
             'transaction_note' => Yii::t('app', 'Transaction Note'),

--- a/common/models/OaBookCostSearch.php
+++ b/common/models/OaBookCostSearch.php
@@ -21,7 +21,7 @@ class OaBookCostSearch extends OaBookCost
             [['id', 'tour_id', 'creator', 'type', 'fid', 'need_to_pay', 'pay_status'], 'integer'],
             [['transaction_fee'], 'number'],
             [['create_time', 'updat_time', 'start_date', 'end_date', 'cl_info', 'due_date_for_pay', 'pay_date', 'transaction_note', 'book_status', 'book_date', 'note', 'pay_method'], 'safe'],
-            [['cny_amount', 'pay_amount'], 'number'],
+            [['cny_amount', 'pay_amount', 'confirmed_amount'], 'number'],
         ];
     }
 
@@ -75,6 +75,7 @@ class OaBookCostSearch extends OaBookCost
             'need_to_pay' => $this->need_to_pay,
             'cny_amount' => $this->cny_amount,
             'pay_status' => $this->pay_status,
+            'confirmed_amount' => $this->confirmed_amount,
             'pay_amount' => $this->pay_amount,
         ]);
 

--- a/common/models/OaPayment.php
+++ b/common/models/OaPayment.php
@@ -19,11 +19,13 @@ use Yii;
  * @property string $due_date
  * @property integer $pay_method
  * @property string $status
+ * @property string $confirmed_amount
  * @property string $receit_account
  * @property string $receit_cny_amount
  * @property string $transaction_fee
  * @property string $receit_date
  * @property string $cc_note_signing
+ * @property string $transaction_note
  * @property string $note
  */
 class OaPayment extends \yii\db\ActiveRecord
@@ -55,8 +57,8 @@ class OaPayment extends \yii\db\ActiveRecord
 			],
             [['inquiry_id', 'tour_id', 'pay_method'], 'integer'],
             [['create_time', 'update_time'], 'safe'],
-            [['cny_amount', 'receit_cny_amount', 'transaction_fee', 'status'], 'number'],
-            [['note'], 'string'],
+            [['cny_amount', 'confirmed_amount', 'receit_cny_amount', 'transaction_fee', 'status'], 'number'],
+            [['note', 'transaction_note'], 'string'],
             [['payer', 'type', 'due_date', 'receit_account', 'receit_date', 'cc_note_signing'], 'string', 'max' => 255],
         ];
     }
@@ -77,13 +79,15 @@ class OaPayment extends \yii\db\ActiveRecord
             'type' => Yii::t('app', 'Type'),
             'cny_amount' => Yii::t('app', 'Amount (CNY)'),
             'due_date' => Yii::t('app', 'Due Date'),
-            'pay_method' => Yii::t('app', 'Payment Method'),
-            'status' => Yii::t('app', 'Payment Status'),
+            'pay_method' => Yii::t('app', 'Pay Method'),
+            'status' => Yii::t('app', 'Pay Status'),
+            'confirmed_amount' => Yii::t('app', 'Confirmed Amount (CNY)'),
             'receit_account' => Yii::t('app', 'Receipt Account'),
-            'receit_cny_amount' => Yii::t('app', 'Receipt Amount (CNY)'),
+            'receit_cny_amount' => Yii::t('app', 'Accounting Amount (CNY)'),
             'transaction_fee' => Yii::t('app', 'Transaction Fee (CNY)'),
-            'receit_date' => Yii::t('app', 'Receipt Date'),
+            'receit_date' => Yii::t('app', 'Accounting Date'),
             'cc_note_signing' => Yii::t('app', 'CC Note Signing'),
+            'transaction_note' => Yii::t('app', 'Transaction Note'),
             'note' => Yii::t('app', 'Note'),
         ];
     }

--- a/common/models/OaPaymentSearch.php
+++ b/common/models/OaPaymentSearch.php
@@ -22,9 +22,9 @@ class OaPaymentSearch extends OaPayment
     {
         return [
             [['id', 'tour_id', 'inquiry_id', 'payer_type'], 'integer'],
-            [['create_time', 'update_time', 'payer', 'type', 'due_date', 'pay_method', 'status', 'receit_account', 'receit_date', 'cc_note_signing', 'note'], 'safe'],
+            [['create_time', 'update_time', 'payer', 'type', 'due_date', 'pay_method', 'status', 'receit_account', 'receit_date', 'cc_note_signing', 'note', 'transaction_note'], 'safe'],
             ['tour_start_date', 'string'],
-            [['cny_amount', 'receit_cny_amount', 'transaction_fee'], 'number'],
+            [['cny_amount', 'confirmed_amount', 'receit_cny_amount', 'transaction_fee'], 'number'],
         ];
     }
 
@@ -94,6 +94,10 @@ class OaPaymentSearch extends OaPayment
         	$sql .= "AND OA_PAYMENT.receit_cny_amount = '$this->receit_cny_amount' ";
 		endif;
 
+		if(!empty($this->confirmed_amount)):
+        	$sql .= "AND OA_PAYMENT.confirmed_amount = '$this->confirmed_amount' ";
+		endif;
+
 		if(!empty($this->transaction_fee)):
         	$sql .= "AND OA_PAYMENT.transaction_fee = '$this->transaction_fee' ";
 		endif;
@@ -132,6 +136,10 @@ class OaPaymentSearch extends OaPayment
 
 		if(!empty($this->cc_note_signing)):
 			$sql .= "AND OA_PAYMENT.cc_note_signing LIKE '%$this->cc_note_signing%' ";
+		endif;
+
+		if(!empty($this->transaction_note)):
+			$sql .= "AND OA_PAYMENT.transaction_note LIKE '%$this->transaction_note%' ";
 		endif;
 
 		if(!empty($this->note)):


### PR DESCRIPTION
/oa-payment/create
/oa-payment/update
1. Add a new field below "Payment Status": "Confirmed Amount (CNY)", decimal, default Empty, (initializing its value same as "Receipt Amount" for all existing payment items);
2. Add a new field below "CC Note Signing": "Transaction Note", multiline text, default Empty, (initializing its content same as "Note" for all existing payment items);
3. Only Admin and Accountant are allowed to edit "Confirmed Amount" and "Transaction Note"(same permission as "Receipt Amount");
4. Add "Clear" for "Receipt Date";


/oa-payment/view
1. Add "Confirmed Amount" below "Payment Status";
2. Add "Transaction Note" below "CC Note Signing";


/oa-payment/index
1. add "Confirmed Amount" after "Status";
2. add SUM for "Confirmed Amount";
3. add "Transaction Note" into "Status" popout;


/oa-book-cost/update
1. Add a new field below "Pay Status": "Confirmed Amount (CNY)", decimal, default Empty, (initializing its value eauql to "Pay Amount" for all existing payment items);
2. Only Admin and Accountant are allowed to edit "Confirmed Amount" (same permission as "Pay Amount");
3. Move "Pay Date" to below "Pay Amount (CNY)";


/oa-book-cost/view
1. Add "Confirmed Amount" below "Pay Status";
2. Move "Pay Date" to below "Pay Amount (CNY)";


/oa-book-cost/index
1. add "Confirmed Amount" after "Pay Status";
2. add SUM for "Confirmed Amount";
3. Move "Pay Date" to after "Pay Amount";

---

oa-payment/create
/oa-payment/update
1. Make these default empty: Confirmed Amount / Receipt Amount / Transaction Fee;
2. "Clear" for "Receipt Date", only admin and accountant can access;
3. Change text:
"Confirmed Amount" to "Confirmed Amount (CNY)"
"Payment Method" to "Pay Method"
"Receipt Amount (CNY)" to "Accounting Amount (CNY)"
"Receipt Date" to "Accounting Date"


/oa-payment/view
1. Change text:
"Payment Method" to "Pay Method"
"Receipt Amount" to "Accounting Amount"
"Receipt Date" to "Accounting Date"


/oa-payment/index
1. Change text:
"Receipt Amount" to "Accounting Amount"
"Receipt Date" to "Accounting Date"



/oa-book-cost/update
1. Make this field default empty: Confirmed Amount (CNY) /  Transaction Fee;
2. Change text:
"Pay Amount (CNY)" to "Accounting Amount (CNY)"
"Pay Date" to "Accounting Date"


/oa-book-cost/view
1. Change text:
"Confirmed Amount (CNY)" to "Confirmed Amount"
"Pay Amount" to "Accounting Amount"
"Pay Date" to "Accounting Date"


/oa-book-cost/index
1. Change text:
"Pay Amount" to "Accounting Amount"
"Pay Date" to "Accounting Date"

---

/oa-payment/create
/oa-payment/update
1. Change text:
"Payment Status" to "Pay Status"

/oa-payment/view
1. Change text:
"Confirmed Amount (CNY)" to "Confirmed Amount"
"Payment Status" to "Pay Status"

/oa-payment/index
1. Change text:
"Confirmed Amount (CNY)" to "Confirmed Amount"

/oa-book-cost/update
1. Make this field default empty: Transaction Fee; now it still has default 0;


/oa-tour/view
/oa-inquiry/view
Payment Section:
1. add "Confirmed Amount" after "Status";
2. add SUM for "Confirmed Amount";
1. Change text:
"Cny Amount" to "Amount"
"Receipt Amount" to "Accounting Amount"
"Receipt Date" to "Accounting Date"

Book Cost Section:
1. add "Confirmed Amount" after "Pay Status";
2. add SUM for "Confirmed Amount";
3. Change text: "Pay Amount" to "Accounting Amount"