### PR TITLE
Various changes to OA Tour, Book Cost and Inquiry

### DIFF
--- a/backend/views/oa-book-cost/_form.php
+++ b/backend/views/oa-book-cost/_form.php
@@ -71,7 +71,7 @@ use yii\helpers\ArrayHelper;
 
     <?= $form->field($model, 'pay_method')->dropdownList(common\models\Tools::getEnvironmentVariable('oa_pay_method'), ['prompt' => '--Select--', 'disabled' => !$permission['canAdd']]) ?>
 
-    <?= $form->field($model, 'transaction_fee')->textInput(['disabled' => !$permission['canAdd']]) ?>
+    <!-- <?= $form->field($model, 'transaction_fee')->textInput(['disabled' => !$permission['canAdd']]) ?> -->
 
     <?= $form->field($model, 'transaction_note')->textarea(['rows' => 6, 'disabled' => !$permission['canAdd']]) ?>
 

--- a/backend/views/oa-book-cost/index.php
+++ b/backend/views/oa-book-cost/index.php
@@ -102,8 +102,21 @@ $this->params['breadcrumbs'][] = $this->title;
             [
                 'attribute'=>'pay_status',
                 'filter'=> \common\models\Tools::getEnvironmentVariable('oa_pay_status'),
+                'format' => 'raw',
                 'value' => function ($data) {
-                    return $data['pay_status'] == 0 ? 'Not Paid' : 'Paid';
+	                $notPaid = 'Not Paid';
+	                $paid = 'Paid';
+	                $transactionNote = '';
+                	
+                	if(!empty(htmlspecialchars($data["transaction_note"]))):
+						$transactionNote = 'Transaction Note: '.htmlspecialchars($data["transaction_note"]);
+                	endif;
+	                	
+	                if(!empty($transactionNote)):
+	                	return $data['pay_status'] == 0 ? '<a tabindex="0" data-html="true" data-placement="left" data-toggle="popover" data-trigger="focus" title="Notes" data-content="'.$transactionNote.'" style="text-decoration: underline; cursor:pointer;">'.$notPaid.'</a>' : '<a tabindex="0" data-html="true" data-placement="left" data-toggle="popover" data-trigger="focus" title="Notes" data-content="'.$transactionNote.'" style="text-decoration: underline; cursor:pointer;">'.$paid.'</a>';
+	  	            endif;
+	  	            
+                    return $data['pay_status'] == 0 ? $notPaid : $paid;
                 }
             ],
             [
@@ -132,10 +145,6 @@ $this->params['breadcrumbs'][] = $this->title;
         			return '-';
                 }
             ],
-            [
-                'attribute'=>'transaction_fee',
-				'footer' => \common\models\Tools::getTotal($dataProvider->models, 'transaction_fee'),
-            ],
             
             // 'create_time',
             // 'updat_time',
@@ -160,3 +169,13 @@ $this->params['breadcrumbs'][] = $this->title;
         ],
     ]); ?>
 </div>
+
+<?php
+$js = <<<JS
+	/* To initialize BS3 popovers set this below */
+	$(function () { 
+	    $("[data-toggle='popover']").popover(); 
+	});
+JS;
+$this->registerJs($js);
+?>

--- a/backend/views/oa-book-cost/view.php
+++ b/backend/views/oa-book-cost/view.php
@@ -68,7 +68,7 @@ $this->params['breadcrumbs'][] = $this->title;
             ],
             'pay_date',
             'pay_method',
-            'transaction_fee',
+            // 'transaction_fee',
             'transaction_note:ntext',
             'note:ntext',
         ],

--- a/backend/views/oa-inquiry/index.php
+++ b/backend/views/oa-inquiry/index.php
@@ -14,7 +14,7 @@ $this->params['breadcrumbs'][] = $this->title;
 ?>
 
 <?php
-$now = time();
+$now = strtotime(date('Y-m-d'));
 $secondsInOneDay = 86400;
 ?>
 
@@ -257,8 +257,30 @@ $secondsInOneDay = 86400;
 	                            	endif;
 		                            
 		                            // if inquiry needs to be updated
-		                            $updateTime = strtotime($value['update_time']);
-		                            if($value['inquiry_status_txt'] == 'New' || ($value['inquiry_status_txt'] == 'Following up' && (($now - $updateTime) / $secondsInOneDay) >= 5)):
+		                            $updateTime = strtotime(date('Y-m-d', strtotime($value['update_time'])));
+		                            $createTime = strtotime(date('Y-m-d', strtotime($value['create_time'])));
+		                            
+		                            if($value['inquiry_status_txt'] == 'New'
+		                            	||
+			                            (
+			                            	$value['inquiry_status_txt'] == 'Following up'
+			                            	&&
+											(                            	
+				                            	((($now - $updateTime) / $secondsInOneDay) >= 2 && (($now - $createTime) / $secondsInOneDay) <= 7)
+				                            	||
+				                            	(
+													(
+														((($now - $createTime) / $secondsInOneDay) > 7 && (($now - $createTime) / $secondsInOneDay) <= 30 && (($now - $updateTime) / $secondsInOneDay) >= 7) || ((($now - $createTime) / $secondsInOneDay) > 30 && (($now - $updateTime) / $secondsInOneDay) >= 30)
+													)
+													&&
+													(
+														empty($value['task_remind']) || empty($value['task_remind_date']) || (!empty($value['task_remind_date']) && strtotime($value['task_remind_date']) < $now)
+													)
+												)
+				                            )
+				                        )
+			                        )
+		                            :
 		                            	echo '<div style="color: #c55">Update follow-up status!</div>';
 		                            endif;
 	

--- a/backend/views/oa-payment/index.php
+++ b/backend/views/oa-payment/index.php
@@ -96,7 +96,7 @@ HTML;
                 		$note = 'Note: '.htmlspecialchars($data["note"]);
                 	endif;
 	                	
-	                if(!empty($note) || !empty($transationNote)):
+	                if(!empty($note) || !empty($transactionNote)):
 	                	return $data['status'] == 0 ? '<a tabindex="0" data-html="true" data-placement="left" data-toggle="popover" data-trigger="focus" title="Notes" data-content="'.$transactionNote.$note.'" style="text-decoration: underline; cursor:pointer;">'.$notPaid.'</a>' : '<a tabindex="0" data-html="true" data-placement="left" data-toggle="popover" data-trigger="focus" title="Notes" data-content="'.$transactionNote.$note.'" style="text-decoration: underline; cursor:pointer;">'.$paid.'</a>';
 	  	            endif;
 	  	            

--- a/backend/views/oa-tour/index.php
+++ b/backend/views/oa-tour/index.php
@@ -203,7 +203,7 @@ $this->params['breadcrumbs'][] = $this->title;
 		                            if($value['task_remind'] && $value['task_remind_date']):
 		                            	$taskRemindDate = strtotime($value['task_remind_date']);
 		                            	if($now >= $taskRemindDate):
-		                            		echo '<div style="color: #28b500">Due task: ' . $value['task_remind'].'</div>';
+		                            		echo '<div class="due-task-notice">Due task: ' . $value['task_remind'].'</div>';
 		                            	endif;
 		                            endif;
 		                            
@@ -221,43 +221,52 @@ $this->params['breadcrumbs'][] = $this->title;
 									   empty($value['number_of_travelers']) ||
 									   empty($value['contact']) ||
 									   empty($value['email'])):
-										echo '<div style="color: #c55">Missing important info!</div>';
+										echo '<div class="other-notice">Missing important info!</div>';
 	                            	endif;
 	                            	
 	                            	// if tour hasn't been closed after 45 days
 	                            	$tourEndDate = strtotime($value['tour_end_date']);
 	                            	if((($now - $tourEndDate) / $secondsInOneDay) >= 45 && !$value['close']):
-	                            		echo '<div style="color: #c55">Needs to be closed!</div>';
+	                            		echo '<div class="other-notice">Needs to be closed!</div>';
 	                            	endif;
 	                            	
 	                            	// needs pre-tour confirmation OR tour has ended and stage hasn't been changed
 	                            	$tourStartDate = strtotime($value['tour_start_date']);
-	                            	if(((($tourStartDate - $now) / $secondsInOneDay) <= 15 &&
-	                            		 in_array($value['stage'], array('Need to Schedule', 'All Scheduled & Need Pre-Tour Confirm'))) || ((($now - $tourEndDate)/$secondsInOneDay) >= 3 &&
-	                            		 in_array($value['stage'], array('Need to Schedule', 'All Scheduled & Need Pre-Tour Confirm', 'Pre-Tour Confirmed & Ready to Go')))):
-	                            		echo '<div style="color: #c55">Abnormal tour stage!</div>';
+	                            	if(
+	                            		((($tourStartDate - $now) / $secondsInOneDay) <= 15 && $value['stage'] == 'Need to Schedule')
+										||
+										((($tourStartDate - $now)/$secondsInOneDay) <= 7 && $value['stage'] == 'All Scheduled & Need Pre-Tour Confirm')
+										||
+										((($now - $tourEndDate)/$secondsInOneDay) >= 3 && $value['stage'] == 'Pre-Tour Confirmed & Ready to Go')
+									):
+	                            		echo '<div class="other-notice">Abnormal tour stage!</div>';
 	                            	endif;
 	                            	
 	                            	// if payments missing
 									if($value['tour_price'] != $value['total_payments']):
-										echo '<div style="color: #c55">Tour price must equal total payments!</div>';
+										echo '<div class="other-notice">Tour price must equal total payments!</div>';
 	                            	endif;
 	                            	
 	                            	// if payment(s) overdue
 									if($value['payment_overdue'] == 1):
-										echo '<div style="color: #c55">Payment(s) overdue!</div>';
+										echo '<div class="other-notice">Payment(s) overdue!</div>';
 	                            	endif;
 	                            	
 	                            	// if no confirmed payments
 									if($value['no_confirmed_payments'] == 1):
-										echo '<div style="color: #c55">No confirmed payment!</div>';
+										echo '<div class="other-notice">No confirmed payment!</div>';
 	                            	endif;
 	                            	
 	                            	// if low profit risk
 	                            	if(!empty($value['tour_price'])):
 										if(!$value['close'] && (($value['tour_price'] - $value['estimated_cost'])/$value['tour_price']) < 0.15):
-											echo '<div style="color: #c55">Low profit risk!</div>';
+											echo '<div class="other-notice">Low profit risk!</div>';
 		                            	endif;
+	                            	endif;
+	                            	
+	                            	// if Accounting Profit != Confirmed Profit!
+									if(($value['pay_confirmed_amount'] - $value['cost_confirmed_amount']) != ($value['pay_accounting_amount'] - $value['cost_accounting_amount'])):
+										echo '<div  class="other-notice">Accounting Profit != Confirmed Profit</div>';
 	                            	endif;
 		                           	?>
 	                            </td>

--- a/backend/web/css/site.css
+++ b/backend/web/css/site.css
@@ -134,3 +134,13 @@ a.desc:after {
 }
 
 .important-info:after {content: " *"; color: red;}
+
+.other-notice {
+	color: #c55;
+	padding: 2px 0px
+}
+
+.due-task-notice {
+	color: #28b500;
+	padding: 2px 0px
+}


### PR DESCRIPTION
/oa-book-cost/index
1. Add popout link for "Status", show Transaction Note content; ✓
2. remove "Transaction Fee" column; ✓

/oa-book-cost/update
/oa-book-cost/view
1. hide "Transaction Fee" field;

/oa-inquiry/index
1. Change display condition for "Update Follow-up Status!": ✓

(Inquiry Status = New)
OR
(
   (Inquiry Status = Following Up)
   AND
   (
       (Today - Create Date)<=7 days AND (Today - Update date)>=2 days

       OR

       (
           (7 days<(Today - Create Date)<=30 days AND (Today - Update date)>=7 days) OR ((Today - Create Date)>30 days AND (Today - Update date)>=30 days)
           AND
           (Task Remind is empty OR Task Remind Date is empty OR Task Remind Date<today)
    )
)

/oa-tour/index
1. Change display condition for "Payment(s) overdue!":
 If a payment of a tour: (Pay Status=Not Paid) AND (Today >= Due Date) ✓
2. Add a warning "Accounting Profit != Confirmed Profit!" When a tour: [Payment.SUM(Confirmed Amount)-Cost.SUM(Confirmed Amount)]!=[Payment.SUM(Accounting Amount)-Cost.SUM(Accounting Amount)] ✓

/oa-tour/index
3. Change display condition for "Abnormal tour stage!": ✓
(Tour Start Date - Today) <= 15 days AND (Tour Stage = "Need to Schedule") OR
(Tour Start Date - Today) <= 7 days AND (Tour Stage = "All Scheduled & Need Pre-Tour Confirm") OR
(Today - Tour End Date) >= 3 days AND (Tour Stage = "Pre-Tour Confirmed and Ready to Go")